### PR TITLE
mobile: register all providers in init() and accept provider parameter in Start

### DIFF
--- a/mobile/mobile.go
+++ b/mobile/mobile.go
@@ -13,9 +13,40 @@ import (
 	"github.com/openlibrecommunity/olcrtc/internal/client"
 	"github.com/openlibrecommunity/olcrtc/internal/logger"
 	"github.com/openlibrecommunity/olcrtc/internal/protect"
+	"github.com/openlibrecommunity/olcrtc/internal/provider"
+	"github.com/openlibrecommunity/olcrtc/internal/provider/jazz"
+	"github.com/openlibrecommunity/olcrtc/internal/provider/telemost"
+	"github.com/openlibrecommunity/olcrtc/internal/provider/wbstream"
 
 	_ "golang.org/x/mobile/bind" // ensure gomobile bind is available
 )
+
+// Provider name constants exposed to mobile callers. Use these strings (or
+// the matching string values) when calling Start.
+const (
+	ProviderTelemost = "telemost"
+	ProviderJazz     = "jazz"
+	ProviderWBStream = "wb_stream"
+)
+
+//nolint:gochecknoinits // mobile bindings rely on init() to register providers
+// because the cmd/olcrtc main binary is not invoked here.
+func init() {
+	provider.Register(ProviderTelemost, telemost.New)
+	provider.Register(ProviderJazz, jazz.New)
+	provider.Register(ProviderWBStream, wbstream.New)
+}
+
+func buildRoomURL(providerName, roomID string) string {
+	switch providerName {
+	case ProviderTelemost:
+		return "https://telemost.yandex.ru/j/" + roomID
+	case ProviderJazz, ProviderWBStream:
+		return roomID
+	default:
+		return roomID
+	}
+}
 
 // SocketProtector protects sockets from VPN routing on Android.
 // Implement this interface in Kotlin/Java and pass to SetProtector.
@@ -32,6 +63,7 @@ var (
 	errAlreadyRunning     = errors.New("olcRTC already running")
 	errRoomIDRequired     = errors.New("roomID is required")
 	errKeyHexRequired     = errors.New("keyHex is required")
+	errProviderRequired   = errors.New("provider is required (telemost|jazz|wb_stream)")
 	errNotRunning         = errors.New("olcRTC is not running")
 	errStoppedBeforeReady = errors.New("olcRTC stopped before becoming ready")
 	errStartTimedOut      = errors.New("olcRTC start timed out")
@@ -76,25 +108,28 @@ func SetDebug(enabled bool) {
 	log.SetFlags(log.Ltime)
 }
 
-// Start launches the olcRTC client in background.
-// roomID: Telemost room ID (e.g. "xxx-xxx-xxx")
+// StartWithProvider launches the olcRTC client in background with an explicit
+// provider name. providerName is one of: "telemost", "jazz", "wb_stream".
+// roomID: provider-specific room identifier
 // keyHex: 64-char hex encryption key
 // socksPort: local SOCKS5 proxy port (e.g. 10808)
 // socksUser/socksPass: SOCKS5 credentials (empty = no auth).
-func Start(roomID, keyHex string, socksPort int, socksUser, socksPass string) error {
+func StartWithProvider(providerName, roomID, keyHex string, socksPort int, socksUser, socksPass string) error {
 	mu.Lock()
 	defer mu.Unlock()
 
 	switch {
 	case cancel != nil:
 		return errAlreadyRunning
+	case providerName == "":
+		return errProviderRequired
 	case roomID == "":
 		return errRoomIDRequired
 	case keyHex == "":
 		return errKeyHexRequired
 	}
 
-	roomURL := "https://telemost.yandex.ru/j/" + roomID
+	roomURL := buildRoomURL(providerName, roomID)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	cancel = cancelFunc
@@ -109,7 +144,7 @@ func Start(roomID, keyHex string, socksPort int, socksUser, socksPass string) er
 
 		err := client.RunWithReady(
 			ctx,
-			"telemost",
+			providerName,
 			roomURL,
 			keyHex,
 			fmt.Sprintf("127.0.0.1:%d", socksPort),
@@ -131,6 +166,12 @@ func Start(roomID, keyHex string, socksPort int, socksUser, socksPass string) er
 	}()
 
 	return nil
+}
+
+// Start preserves the original gomobile signature (Telemost-only) for backward
+// compatibility with callers that have not migrated to StartWithProvider.
+func Start(roomID, keyHex string, socksPort int, socksUser, socksPass string) error {
+	return StartWithProvider(ProviderTelemost, roomID, keyHex, socksPort, socksUser, socksPass)
 }
 
 // WaitReady blocks until the Telemost peers are connected and the local SOCKS5 listener is ready.


### PR DESCRIPTION
## Summary

Fixes two latent bugs in `mobile/mobile.go` that prevent the gomobile-bound AAR from working with anything other than Telemost.

### Bug 1 — provider registry empty in the AAR

Provider registration lives in `cmd/olcrtc/main.go`:

```go
provider.Register("jazz", jazz.New)
provider.Register("telemost", telemost.New)
provider.Register("wb_stream", wbstream.New)
```

…but those calls happen inside `run()`, which `gomobile bind` never invokes. The mobile binding goes straight to `client.RunWithReady(...)`, so the provider registry stays empty and the very first `addPeer` call returns `provider not found` regardless of which provider the mobile caller asked for.

**Fix:** add an `init()` in `mobile/mobile.go` that registers all three providers. Now the registry is populated as soon as the AAR is loaded, before any mobile-side code can call into it.

### Bug 2 — provider hard-coded to telemost in mobile.Start()

`Start()` in `mobile/mobile.go` does:

```go
roomURL := "https://telemost.yandex.ru/j/" + roomID
err := client.RunWithReady(ctx, "telemost", roomURL, ...)
```

So even if the registry were populated, every mobile caller is silently routed to Telemost regardless of what the user picked in the app. SaluteJazz / Wildberries Stream are unreachable from the AAR.

**Fix:** add a new `StartWithProvider(providerName, roomID, keyHex, socksPort, socksUser, socksPass)` that takes the provider name as a parameter and builds the right room URL for it (Telemost gets `https://telemost.yandex.ru/j/<id>`; jazz/wb_stream pass the roomID through verbatim). The old `Start(...)` is preserved as a backward-compat shim that forwards to `StartWithProvider("telemost", ...)`, so existing callers keep working.

### Verification

- The fork [`Oleglog/Exclave_FORK`](https://github.com/Oleglog/Exclave_FORK) pins `library/core/go.mod` at this commit (`e2e7b00`) and calls `Mobile.startWithProvider(...)` from the Kotlin side. With the fix in place, the Android client successfully connects via wb_stream / jazz / telemost (was previously crashing with `provider not found` for jazz / wb_stream and silently misrouting to Telemost).
- Server-side trace confirms the WebRTC peer connects: `Peer 0 connected` + `peer connection state changed: connected`.

## Review & Testing Checklist for Human

- [ ] Confirm the new `init()` does not interfere with non-mobile builds. The file is gated by being inside `mobile/`, which is only consumed by `gomobile bind` callers, but a quick `go build ./...` from the repo root would catch any accidental regressions.
- [ ] Verify the new `StartWithProvider` signature is gomobile-friendly (string + string + string + int + string + string — all primitive types, returns error). Already confirmed by a successful AAR build, but worth re-checking if anyone else has bound this package for iOS / wasm.
- [ ] Spot-check the `buildRoomURL` switch — there are exactly three providers; the default branch falls back to passing `roomID` through verbatim, which is the safe choice for any future provider added later.

### Notes

- Keeping `Start(...)` as a thin shim around `StartWithProvider("telemost", ...)` deliberately — it is part of the documented gomobile surface and removing it would silently break older bindings.
- This branch is intentionally minimal — only `mobile/mobile.go` is touched, no changes to the providers themselves.

---

Created by Devin session: https://app.devin.ai/sessions/cae9f22559af4b7d94ddb8fba608843e
Requested by: lecevex